### PR TITLE
[T-3055][16.0][IMP] repository setup folder

### DIFF
--- a/setup/_metapackage/pyproject.toml
+++ b/setup/_metapackage/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "base_old_migration_fields"
+version = "16.0.20240909.0"
+dependencies = [
+    "odoo-addon-base_old_migration_fields>=16.0dev,<16.1dev",
+]
+classifiers=[
+    "Programming Language :: Python",
+    "Framework :: Odoo",
+    "Framework :: Odoo :: 16.0",
+]

--- a/setup/base_old_migration_fields/odoo/addons/base_old_migration_fields
+++ b/setup/base_old_migration_fields/odoo/addons/base_old_migration_fields
@@ -1,0 +1,1 @@
+../../../../base_old_migration_fields/

--- a/setup/base_old_migration_fields/setup.py
+++ b/setup/base_old_migration_fields/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
Setup folder added so tests in modules for task T-3055 are successful.

It has also been added the file __init__.py in module base_old_migration_fields so the module is identified as installable. This action has been necessary to make the oca-gen-metapackage command work.

T-3055