### PR TITLE
[T-7933][17.0][IMP] odoo_2_odoo_data_transfer: logs and query speed

### DIFF
--- a/odoo_2_odoo_data_transfer/README.rst
+++ b/odoo_2_odoo_data_transfer/README.rst
@@ -25,11 +25,11 @@ Odoo 2 Odoo Data Transfer
 This module offers you tools to transfer data between odoo servers with
 different versions.
 
-- Define the models and fields to migrate from one Odoo and their
-  correspondences with the other Odoo with transference templates
-- Execute the transference templates with a trasference wizard.
-- Keep track of the transfered records, and transference errors with
-  transference logs.
+-  Define the models and fields to migrate from one Odoo and their
+   correspondences with the other Odoo with transference templates
+-  Execute the transference templates with a trasference wizard.
+-  Keep track of the transfered records, and transference errors with
+   transference logs.
 
 **Table of contents**
 
@@ -74,35 +74,35 @@ make sure both fields have similar types.
 If the field types are relational (many2one, many2many, one2many) the
 transference will be more complex and you will have to fill more data:
 
-- If the fields are many2one or many2many, for example: a contact, Odoo
-  will need to associate the remote contact with the local one. For that
-  you will have to choose a Transference method. Note: Creating records
-  is not currently supported, the remote related record has to be
-  created in the local odoo
+-  If the fields are many2one or many2many, for example: a contact, Odoo
+   will need to associate the remote contact with the local one. For
+   that you will have to choose a Transference method. Note: Creating
+   records is not currently supported, the remote related record has to
+   be created in the local odoo
 
-  - "Map ids" is the simplest method, you have to do the associations
-    filling a python dictionary with two keys for each related record,
-    old_id and new_id. For example, if you have the "Pedrito" partner in
-    the remote Odoo with id 6, but his id in the local odoo is 10, the
-    map will be {6:10,}.
+   -  "Map ids" is the simplest method, you have to do the associations
+      filling a python dictionary with two keys for each related record,
+      old_id and new_id. For example, if you have the "Pedrito" partner
+      in the remote Odoo with id 6, but his id in the local odoo is 10,
+      the map will be {6:10,}.
 
-  - "Match keys" is the default method. You have to fill a identifier
-    field for the remote and local model, then odoo will automatically
-    make the associations. In the partner example, you can have the
-    "Vat" field as the identifier for both fields, "Pedrito" should have
-    the same vat in both Odoos and Odoo will identify them as the same
-    contact for having the same identifier field. The map of ids will
-    also be available to manually override the associations if some
-    related records do not have the same value in the key field.
+   -  "Match keys" is the default method. You have to fill a identifier
+      field for the remote and local model, then odoo will automatically
+      make the associations. In the partner example, you can have the
+      "Vat" field as the identifier for both fields, "Pedrito" should
+      have the same vat in both Odoos and Odoo will identify them as the
+      same contact for having the same identifier field. The map of ids
+      will also be available to manually override the associations if
+      some related records do not have the same value in the key field.
 
-- If the related field has one2many type, there is usually a strong
-  dependency between the fields, and in this case we have to create the
-  records of the related model at the same time. For example, if you are
-  transferring posted invoices, you will have to transfer its invoice
-  lines at the same time. In order to do that, you have to fill the
-  "One2Many Template" field with another data transfer template for the
-  related model, that second transfer template should have the "Is
-  Many2One Template" boolean field set as true.
+-  If the related field has one2many type, there is usually a strong
+   dependency between the fields, and in this case we have to create the
+   records of the related model at the same time. For example, if you
+   are transferring posted invoices, you will have to transfer its
+   invoice lines at the same time. In order to do that, you have to fill
+   the "One2Many Template" field with another data transfer template for
+   the related model, that second transfer template should have the "Is
+   Many2One Template" boolean field set as true.
 
 Import / export data transfer templates
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -154,43 +154,52 @@ on the Transference log, fix the data, and repeat the migration process.
 On every failed record, the remote id and the error message are shown.
 We have 2 types of errors:
 
-- Missing Errors: Records that could not be migrated because another
-  related record could not be found locally. For example, if we are
-  migrating a sale order of our customer "Pedro", and "Pedro" could not
-  be found locally, this error will be generated. To have the missing
-  error you have some common options.
+-  Missing Errors: Records that could not be migrated because another
+   related record could not be found locally. For example, if we are
+   migrating a sale order of our customer "Pedro", and "Pedro" could not
+   be found locally, this error will be generated. To have the missing
+   error you have some common options.
 
-  - If the record does not exist you can create it.
-  - If the record does exist but the key has changed, you can edit it to
-    be the same
-  - If the record does exist but the key has changed, you can add the
-    remote id and the local id to the id mappings of the template.
-  - If fixing the data is too difficult or expensive, you can skip the
-    errors with the "Skip Relational Errors" of the migration template
-    line. If a related field is not found, it will be set to false
-    instead of throwing an error.
+   -  If the record does not exist you can create it.
+   -  If the record does exist but the key has changed, you can edit it
+      to be the same
+   -  If the record does exist but the key has changed, you can add the
+      remote id and the local id to the id mappings of the template.
+   -  If fixing the data is too difficult or expensive, you can skip the
+      errors with the "Skip Relational Errors" of the migration template
+      line. If a related field is not found, it will be set to false
+      instead of throwing an error.
 
-- Other errors: The rest of the errors. Less common but more difficult
-  to resolve, they will probably need a developer.
+-  Other errors: The rest of the errors. Less common but more difficult
+   to resolve, they will probably need a developer.
 
-If you execute again the same Transference template, the already
-transferred records will be queried in the logs, and omitted in the next
-migration process. They will also be shown in the "Already Transferred
-Records" tab of the migration log notebook.
+If you execute again the same Transference template, the last transfered
+record will be queried in the logs, the next migration process will
+start from that record.
 
 You can repeat the execution of the migration process until there are no
 errors in the migration log.
+
+The failed records won't be included in the next migration process if
+they are before that last migrated record, if you have fixed the
+problems and you want to include again the failed records in the
+migration, you should mark the "Migrate Failed" check of the migration
+wizard, then it will only try to migrate those failed records.
 
 Known issues / Roadmap
 ======================
 
 Improvements proposed:
 
-- Use module queue job or odoo triggers to queue the migration process.
-- Add unit tests, at least for many2one and many2many field transfer.
-- Add write mode
-- Match records by external id
-- Add smartbutton to see a list of migrated records in log
+-  Use module queue job or odoo triggers to queue the migration process.
+-  Add unit tests, for:
+
+   -  many2one and many2many field transferences.
+   -  The migrate_archived option of the wizard.
+
+-  Add write mode
+-  Match records by external id
+-  Add smartbutton to see a list of migrated records in log
 
 Bug Tracker
 ===========
@@ -213,10 +222,10 @@ Authors
 Contributors
 ------------
 
-- Alberto Martínez alberto.martinez@sygel.es
-- Manuel Regidor manuel.regidor@sygel.es
-- Valentin Vinagre valentin.vinagre@sygel.es
-- Harald Panten harald.panten@sygel.es
+-  Alberto Martínez alberto.martinez@sygel.es
+-  Manuel Regidor manuel.regidor@sygel.es
+-  Valentin Vinagre valentin.vinagre@sygel.es
+-  Harald Panten harald.panten@sygel.es
 
 Maintainers
 -----------

--- a/odoo_2_odoo_data_transfer/i18n/es.po
+++ b/odoo_2_odoo_data_transfer/i18n/es.po
@@ -789,3 +789,23 @@ msgstr "Validar"
 #: model:ir.model.fields,field_description:odoo_2_odoo_data_transfer.field_odoo_data_transfer_wizard__warn_msg
 msgid "Warn Msg"
 msgstr "Mensaje de aviso"
+
+#. module: odoo_2_odoo_data_transfer
+#: model:ir.model.fields,field_description:odoo_2_odoo_data_transfer.field_odoo_data_transfer_log__first_transferred_id
+msgid "First Transferred"
+msgstr "Primer transferido"
+
+#. module: odoo_2_odoo_data_transfer
+#: model:ir.model.fields,field_description:odoo_2_odoo_data_transfer.field_odoo_data_transfer_log__last_transferred_id
+msgid "Last Transferred"
+msgstr "Ultimo transferido"
+
+#. module: odoo_2_odoo_data_transfer
+#: model:ir.model.fields,field_description:odoo_2_odoo_data_transfer.field_odoo_data_transfer_log__is_failed_migration
+msgid "Is Failed Migration"
+msgstr "Es migración de fallidos"
+
+#. module: odoo_2_odoo_data_transfer
+#: model:ir.model.fields,field_description:odoo_2_odoo_data_transfer.field_odoo_data_transfer_wizard__migrate_failed
+msgid "Migrate Failed"
+msgstr "Migrar fallidos"

--- a/odoo_2_odoo_data_transfer/models/odoo_data_transfer_log.py
+++ b/odoo_2_odoo_data_transfer/models/odoo_data_transfer_log.py
@@ -48,12 +48,6 @@ class OdooDataTransferTemplateLog(models.Model):
         inverse_name="log_id",
         domain=["|", ("error_type", "=", False), ("error_type", "=", "ok")],
     )
-    already_transfered_record_ids = fields.One2many(
-        string="Already transfered records",
-        comodel_name="odoo.data.transfer.log.record",
-        inverse_name="log_id",
-        domain=[("error_type", "=", "already_transfered")],
-    )
     missing_error_record_ids = fields.One2many(
         string="Records with Missing Errors",
         comodel_name="odoo.data.transfer.log.record",
@@ -67,23 +61,55 @@ class OdooDataTransferTemplateLog(models.Model):
         domain=[("error_type", "=", "other_error")],
     )
     transfered_records_counter = fields.Integer(
-        compute="_compute_transfered_records_counter"
+        compute="_compute_transfered_records_counter",
+        store=True,
     )
     record_total_counter = fields.Integer()
+
+    first_transferred_id = fields.Integer(
+        compute="_compute_transfered_records_counter",
+        store=True,
+    )
+    last_transferred_id = fields.Integer(
+        compute="_compute_transfered_records_counter",
+        store=True,
+    )
+    is_failed_migration = fields.Boolean(readonly=True)
 
     @api.depends("transfered_records_ids")
     def _compute_transfered_records_counter(self):
         for rec in self:
             rec.transfered_records_counter = len(rec.transfered_records_ids)
+            rec.first_transferred_id = (
+                self.env["odoo.data.transfer.log.record"]
+                .search([("log_id", "=", rec.id)], order="remote_id asc", limit=1)
+                .remote_id
+            )
+            rec.last_transferred_id = (
+                self.env["odoo.data.transfer.log.record"]
+                .search([("log_id", "=", rec.id)], order="remote_id desc", limit=1)
+                .remote_id
+            )
 
     @api.model
-    def _get_transfered_record_log_lines(self, model_id):
-        """Returns record of model created befor with this module"""
-        return (
-            self.search([("local_target_model_id", "=", model_id.id)])
-            .mapped("transfered_records_ids")
-            .filtered(lambda li: li.local_id and li.local_id.exists())
-        )
+    def _get_last_transfered_record_id(self, model_id):
+        return self.search(
+            [("local_target_model_id", "=", model_id.id)],
+            order="last_transferred_id desc",
+            limit=1,
+        ).last_transferred_id
+
+    @api.model
+    def _get_failed_record_ids(self, model_id):
+        failed_records = set()
+        fixed_records = set()
+        logs = self.search([("local_target_model_id", "=", model_id.id)])
+        for log in logs:
+            failed_records.update(log.missing_error_record_ids.mapped("remote_id"))
+            failed_records.update(log.other_error_record_ids.mapped("remote_id"))
+            if log.is_failed_migration:
+                fixed_records.update(log.transfered_records_ids.mapped("remote_id"))
+        return failed_records - fixed_records
 
     def action_log(self):
         self.ensure_one()
@@ -94,28 +120,6 @@ class OdooDataTransferTemplateLog(models.Model):
             "res_model": "odoo.data.transfer.log",
             "res_id": self.id,
         }
-
-    def _copy_transfered_records_ids(self, transfered_records_ids):
-        """Creates in already_transfered_record_ids of self
-        another transfered_records_ids"""
-        already_transfered_records_dict = {}
-        already_transfered_records_dict.update(
-            {
-                "already_transfered_record_ids": [
-                    (
-                        0,
-                        0,
-                        {
-                            "remote_id": rec.remote_id,
-                            "local_id": f"{rec.local_id._name},{rec.local_id.id}",
-                            "error_type": "already_transfered",
-                        },
-                    )
-                    for rec in transfered_records_ids
-                ]
-            }
-        )
-        self.write(already_transfered_records_dict)
 
     def _calculate_state(self):
         for rec in self:

--- a/odoo_2_odoo_data_transfer/readme/ROADMAP.md
+++ b/odoo_2_odoo_data_transfer/readme/ROADMAP.md
@@ -1,7 +1,9 @@
 Improvements proposed:
 
 - Use module queue job or odoo triggers to queue the migration process.
-- Add unit tests, at least for many2one and many2many field transfer.
+- Add unit tests, for:
+    - many2one and many2many field transferences.
+    - The migrate_archived option of the wizard.
 - Add write mode
 - Match records by external id
 - Add smartbutton to see a list of migrated records in log

--- a/odoo_2_odoo_data_transfer/readme/USAGE.md
+++ b/odoo_2_odoo_data_transfer/readme/USAGE.md
@@ -68,6 +68,8 @@ On every failed record, the remote id and the error message are shown. We have 2
 
 - Other errors: The rest of the errors. Less common but more difficult to resolve, they will probably need a developer.
 
-If you execute again the same Transference template, the already transferred records will be queried in the logs, and omitted in the next migration process. They will also be shown in the "Already Transferred Records" tab of the migration log notebook. 
+If you execute again the same Transference template, the last transfered record will be queried in the logs, the next migration process will start from that record. 
 
 You can repeat the execution of the migration process until there are no errors in the migration log.
+
+The failed records won't be included in the next migration process if they are before that last migrated record, if you have fixed the problems and you want to include again the failed records in the migration, you should mark the "Migrate Failed" check of the migration wizard, then it will only try to migrate those failed records.

--- a/odoo_2_odoo_data_transfer/static/description/index.html
+++ b/odoo_2_odoo_data_transfer/static/description/index.html
@@ -435,32 +435,32 @@ make sure both fields have similar types.</p>
 transference will be more complex and you will have to fill more data:</p>
 <ul class="simple">
 <li>If the fields are many2one or many2many, for example: a contact, Odoo
-will need to associate the remote contact with the local one. For that
-you will have to choose a Transference method. Note: Creating records
-is not currently supported, the remote related record has to be
-created in the local odoo<ul>
+will need to associate the remote contact with the local one. For
+that you will have to choose a Transference method. Note: Creating
+records is not currently supported, the remote related record has to
+be created in the local odoo<ul>
 <li>“Map ids” is the simplest method, you have to do the associations
 filling a python dictionary with two keys for each related record,
-old_id and new_id. For example, if you have the “Pedrito” partner in
-the remote Odoo with id 6, but his id in the local odoo is 10, the
-map will be {6:10,}.</li>
+old_id and new_id. For example, if you have the “Pedrito” partner
+in the remote Odoo with id 6, but his id in the local odoo is 10,
+the map will be {6:10,}.</li>
 <li>“Match keys” is the default method. You have to fill a identifier
 field for the remote and local model, then odoo will automatically
 make the associations. In the partner example, you can have the
-“Vat” field as the identifier for both fields, “Pedrito” should have
-the same vat in both Odoos and Odoo will identify them as the same
-contact for having the same identifier field. The map of ids will
-also be available to manually override the associations if some
-related records do not have the same value in the key field.</li>
+“Vat” field as the identifier for both fields, “Pedrito” should
+have the same vat in both Odoos and Odoo will identify them as the
+same contact for having the same identifier field. The map of ids
+will also be available to manually override the associations if
+some related records do not have the same value in the key field.</li>
 </ul>
 </li>
 <li>If the related field has one2many type, there is usually a strong
 dependency between the fields, and in this case we have to create the
-records of the related model at the same time. For example, if you are
-transferring posted invoices, you will have to transfer its invoice
-lines at the same time. In order to do that, you have to fill the
-“One2Many Template” field with another data transfer template for the
-related model, that second transfer template should have the “Is
+records of the related model at the same time. For example, if you
+are transferring posted invoices, you will have to transfer its
+invoice lines at the same time. In order to do that, you have to fill
+the “One2Many Template” field with another data transfer template for
+the related model, that second transfer template should have the “Is
 Many2One Template” boolean field set as true.</li>
 </ul>
 </div>
@@ -516,8 +516,8 @@ migrating a sale order of our customer “Pedro”, and “Pedro” could not
 be found locally, this error will be generated. To have the missing
 error you have some common options.<ul>
 <li>If the record does not exist you can create it.</li>
-<li>If the record does exist but the key has changed, you can edit it to
-be the same</li>
+<li>If the record does exist but the key has changed, you can edit it
+to be the same</li>
 <li>If the record does exist but the key has changed, you can add the
 remote id and the local id to the id mappings of the template.</li>
 <li>If fixing the data is too difficult or expensive, you can skip the
@@ -529,12 +529,16 @@ instead of throwing an error.</li>
 <li>Other errors: The rest of the errors. Less common but more difficult
 to resolve, they will probably need a developer.</li>
 </ul>
-<p>If you execute again the same Transference template, the already
-transferred records will be queried in the logs, and omitted in the next
-migration process. They will also be shown in the “Already Transferred
-Records” tab of the migration log notebook.</p>
+<p>If you execute again the same Transference template, the last transfered
+record will be queried in the logs, the next migration process will
+start from that record.</p>
 <p>You can repeat the execution of the migration process until there are no
 errors in the migration log.</p>
+<p>The failed records won’t be included in the next migration process if
+they are before that last migrated record, if you have fixed the
+problems and you want to include again the failed records in the
+migration, you should mark the “Migrate Failed” check of the migration
+wizard, then it will only try to migrate those failed records.</p>
 </div>
 </div>
 </div>
@@ -543,7 +547,11 @@ errors in the migration log.</p>
 <p>Improvements proposed:</p>
 <ul class="simple">
 <li>Use module queue job or odoo triggers to queue the migration process.</li>
-<li>Add unit tests, at least for many2one and many2many field transfer.</li>
+<li>Add unit tests, for:<ul>
+<li>many2one and many2many field transferences.</li>
+<li>The migrate_archived option of the wizard.</li>
+</ul>
+</li>
 <li>Add write mode</li>
 <li>Match records by external id</li>
 <li>Add smartbutton to see a list of migrated records in log</li>

--- a/odoo_2_odoo_data_transfer/views/odoo_data_transfer_log.xml
+++ b/odoo_2_odoo_data_transfer/views/odoo_data_transfer_log.xml
@@ -15,7 +15,7 @@
                     context="{'technical_display_name': True}"
                 />
                     <field name="state" />
-                    <field name="transfered_records_ids" />
+                    <field name="transfered_records_counter" />
                </tree>
           </field>
      </record>
@@ -33,15 +33,19 @@
                               <group>
                                    <field name="remote_source_model_name" />
                                    <field name="local_target_model_id" />
-                                   <field name="domain" />
                                    <field name="date_start" />
                                    <field name="date_end" />
-                                   <field name="transfered_records_counter" />
-                                   <field name="record_total_counter" />
                               </group>
                               <group>
                                    <field name="url" />
                                    <field name="db_name" />
+                              </group>
+                              <group>
+                                   <field name="domain" />
+                                   <field name="transfered_records_counter" />
+                                   <field name="record_total_counter" />
+                                   <field name="first_transferred_id" />
+                                   <field name="last_transferred_id" />
                               </group>
                          </group>
                          <notebook>
@@ -58,18 +62,6 @@
                                    <group>
                                         <field
                                     name="transfered_field_ids"
-                                    nolabel="1"
-                                    colspan="2"
-                                />
-                                   </group>
-                              </page>
-                              <page
-                            name="already_transfered"
-                            string="Already Transfered Records"
-                        >
-                                   <group>
-                                        <field
-                                    name="already_transfered_record_ids"
                                     nolabel="1"
                                     colspan="2"
                                 />

--- a/odoo_2_odoo_data_transfer/wizards/odoo_data_transfer_wizard.py
+++ b/odoo_2_odoo_data_transfer/wizards/odoo_data_transfer_wizard.py
@@ -51,6 +51,10 @@ class OdooDataTransferWizard(models.TransientModel):
         help="Useful when migrating translated fields",
     )
     migrate_archived = fields.Boolean(default=True)
+    migrate_failed = fields.Boolean(
+        help="Failed records won't be migrated by default for better automating. "
+        "Mark this check after fixing the data to migrate failed records"
+    )
     state = fields.Selection(
         selection=[("new", "New"), ("validated", "Validated")],
         required=True,
@@ -199,6 +203,7 @@ class OdooDataTransferWizard(models.TransientModel):
                 "db_name": self.db_name,
                 "date_start": datetime.datetime.now(),
                 "transfered_field_ids": (self.transfer_line_ids._copy_line_vals()),
+                "is_failed_migration": self.migrate_failed,
             }
         )
         return res
@@ -290,18 +295,27 @@ class OdooDataTransferWizard(models.TransientModel):
         self.log_id = self._create_logs()
 
         # Calculate relational fields data mappings
+        logging.info("Calculating ID Associations for relational fields")
         for rel_tmpl_line in self._get_relational_lines_to_compute():
             self._autocalculate_id_mappings(wrapper, rel_tmpl_line)
+        logging.info("End of calculation of ID Associations for relational fields")
 
         # Get already transfered records and update domain
-        already_transfered_records = self.env[
-            "odoo.data.transfer.log"
-        ]._get_transfered_record_log_lines(self.local_target_model_id)
-        self.log_id._copy_transfered_records_ids(already_transfered_records)
-        already_transfered_domain = [
-            ("id", "not in", already_transfered_records.mapped("remote_id"))
-        ]
-        final_domain = already_transfered_domain + safe_eval(self.domain)
+        logging.info("Creating transference domain")
+        if not self.migrate_failed:
+            last_transfered_id = self.env[
+                "odoo.data.transfer.log"
+            ]._get_last_transfered_record_id(self.local_target_model_id)
+            already_transfered_domain = [("id", ">", last_transfered_id)]
+            final_domain = already_transfered_domain + safe_eval(self.domain)
+        else:
+            not_transferred_ids = self.env[
+                "odoo.data.transfer.log"
+            ]._get_failed_record_ids(self.local_target_model_id)
+            not_transferred_domain = [("id", "in", list(not_transferred_ids))]
+            final_domain = not_transferred_domain + safe_eval(self.domain)
+        logging.info("End of creation of transference domain")
+        logging.info(f"Domain: {final_domain}")
 
         # Loop records packages
         record_counter = 0

--- a/odoo_2_odoo_data_transfer/wizards/odoo_data_transfer_wizard_views.xml
+++ b/odoo_2_odoo_data_transfer/wizards/odoo_data_transfer_wizard_views.xml
@@ -36,6 +36,7 @@
                             />
                             <field name="migration_lang" />
                             <field name="migrate_archived" />
+                            <field name="migrate_failed" />
                         </group>
                     </group>
                     <group>

--- a/odoo_2_odoo_data_transfer/wizards/odoo_xmlrpc_wrapper.py
+++ b/odoo_2_odoo_data_transfer/wizards/odoo_xmlrpc_wrapper.py
@@ -44,6 +44,7 @@ class OdooXmlrpcWrapper:
         if isinstance(domain, str):
             domain = safe_eval(domain)
         kwargs = {
+            "order": "id",
             "fields": fields,
             "offset": offset,
             "context": {"lang": self.lang, "active_test": not self.archived},


### PR DESCRIPTION
Added the following efficiency improvements:
- Store odoo data transfer template log records count field
- Remove the already transfered records from  odoo data transfer template logs. A field that was being duplicated on each data transference consuming a lot of memory and time
- Query remote records whose id is greater than the last migrated one
- Add an option to just query remote records that failed