### PR TITLE
[T-7933][17.0][FIX] odoo_2_odoo_data_transfer: id_mappings kwargs access.

### DIFF
--- a/odoo_2_odoo_data_transfer/models/odoo_data_transfer_template_mixin.py
+++ b/odoo_2_odoo_data_transfer/models/odoo_data_transfer_template_mixin.py
@@ -59,7 +59,7 @@ class OdooDataTransferTemplateLineMixin(models.AbstractModel):
 
     def _parse_value(self, key, value, **ids_map_map):
         tmpl_line = self._get_template_line(key)
-        ids_map = ids_map_map.get(tmpl_line.id)
+        ids_map = ids_map_map.get(str(tmpl_line.id))
         return tmpl_line._parse_value(value, ids_map)
 
     def _get_new_record_vals(self, record_dict, **ids_map_map):

--- a/odoo_2_odoo_data_transfer/wizards/odoo_data_transfer_wizard.py
+++ b/odoo_2_odoo_data_transfer/wizards/odoo_data_transfer_wizard.py
@@ -302,7 +302,7 @@ class OdooDataTransferWizard(models.TransientModel):
         logging.info("Calculating ID Associations for relational fields")
         ids_map_map = {}  # Ids mappings for each relational line id
         for rel_tmpl_line in self._get_relational_lines_to_compute():
-            ids_map_map[rel_tmpl_line.id] = self._autocalculate_id_mappings(
+            ids_map_map[str(rel_tmpl_line.id)] = self._autocalculate_id_mappings(
                 wrapper, rel_tmpl_line
             )
         logging.info("End of calculation of ID Associations for relational fields")
@@ -348,7 +348,7 @@ class OdooDataTransferWizard(models.TransientModel):
                 break
             # Loop records
             for record_dict in records_data:
-                self.create_record(record_dict, ids_map_map=ids_map_map)
+                self.create_record(record_dict, **ids_map_map)
             logging.info(f"{record_counter} / {record_total} records created")
         self.log_id._calculate_state()
         self.log_id.write(


### PR DESCRIPTION
Keyword args mappings keys should be strings
Keyword args should be passed with ** if they are a dict